### PR TITLE
feat: render custom changeset errors with binary paths

### DIFF
--- a/lib/eview/helpers/changeset_validations_parser.ex
+++ b/lib/eview/helpers/changeset_validations_parser.ex
@@ -74,7 +74,11 @@ if Code.ensure_loaded?(Ecto) do
 
     defp reduce_rule_params(field, validation_name, validations) do
       validations
-      |> Keyword.get_values(field)
+      |> Enum.reduce([], fn
+        {^field, v}, acc -> [v | acc]
+        _, acc -> acc
+      end)
+      |> Enum.reverse()
       |> Enum.reduce([], fn
         # Validation with keywords
         {^validation_name, [h | _] = keyword}, acc when is_tuple(h) ->

--- a/test/acceptance/eview_test.exs
+++ b/test/acceptance/eview_test.exs
@@ -284,19 +284,19 @@ defmodule EViewAcceptanceTest do
              "error" => %{
                "invalid" => [
                  %{
-                   "entry" => "$.loans_count",
-                   "entry_type" => "json_data_property",
-                   "rules" => [
-                     %{"rule" => "required"}
-                   ]
-                 },
-                 %{
                    "entry" => "$.originator",
                    "entry_type" => "json_data_property",
                    "rules" => [
                      %{
                        "rule" => "required"
                      }
+                   ]
+                 },
+                 %{
+                   "entry" => "$.loans_count",
+                   "entry_type" => "json_data_property",
+                   "rules" => [
+                     %{"rule" => "required"}
                    ]
                  }
                ],
@@ -334,7 +334,7 @@ defmodule EViewAcceptanceTest do
                    "rules" => [
                      %{
                        "description" => "value is not allowed in enum",
-                       "params" => ["a", "b"],
+                       "params" => %{"values" => ["a", "b"]},
                        "rule" => "inclusion"
                      }
                    ]
@@ -345,7 +345,7 @@ defmodule EViewAcceptanceTest do
                    "rules" => [
                      %{
                        "description" => "required property loans_count was not present",
-                       "params" => [],
+                       "params" => %{"property" => "loans_count"},
                        "rule" => "required"
                      }
                    ]

--- a/web/controllers/page_controller.ex
+++ b/web/controllers/page_controller.ex
@@ -31,7 +31,7 @@ defmodule Demo.PageController do
         conn
         |> put_status(422)
         |> put_view(EView.Views.ValidationError)
-        |> render("422.json", changeset)
+        |> render("422.json", changeset: changeset)
     end
   end
 


### PR DESCRIPTION
Allows to render custom changeset errors with path to field as a binary